### PR TITLE
Fixing Mosquitto chart + refacto

### DIFF
--- a/mosquitto/Chart.yaml
+++ b/mosquitto/Chart.yaml
@@ -1,5 +1,6 @@
 name: mosquitto
-version: 0.1.3
+apiVersion: v1
+version: 0.1.4
 appVersion: 1.4.12
 description: Mosquitto
 keywords:

--- a/mosquitto/README.md
+++ b/mosquitto/README.md
@@ -86,7 +86,7 @@ cat > mosquitto-values.yaml <<EOF
 config: |-
   log_dest stdout
   listener 1883
-  listener 9090 
+  listener 9090
   protocol websockets
 EOF
 

--- a/mosquitto/templates/configmap.yaml
+++ b/mosquitto/templates/configmap.yaml
@@ -3,12 +3,10 @@ kind: ConfigMap
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }} 
+    heritage: {{ .Release.Service }}
 data:
   mosquitto.conf: |-
-{{- if .Values.config }}
-{{ .Values.config | indent 4 }}
-{{- end -}}
+    {{- .Values.config | nindent 4 }}

--- a/mosquitto/templates/deployment.yaml
+++ b/mosquitto/templates/deployment.yaml
@@ -1,17 +1,24 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+      release: {{ .Release.Name }}
   strategy:
     type: Recreate
   template:
+    hostNetwork: {{ .Values.deployment.hostNetwork }}
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         app: {{ template "fullname" . }}
         release: {{ .Release.Name }}
@@ -25,7 +32,6 @@ spec:
           name: "mqtt"
         - containerPort: 9090
           name: "websocket"
-
         volumeMounts:
           - name: mosquitto-conf
             mountPath: /mosquitto/config/mosquitto.conf
@@ -34,8 +40,13 @@ spec:
           - name: mosquitto-data
             mountPath: /mosquitto/data
             subPath: mosquitto/data
+        {{- with .Values.deployment.probes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.deployment.resources }}
         resources:
-{{ toYaml .Values.resources | indent 10 }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       volumes:
       - name: mosquitto-conf
         configMap:

--- a/mosquitto/templates/pvc.yaml
+++ b/mosquitto/templates/pvc.yaml
@@ -4,22 +4,17 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }} 
+    heritage: {{ .Release.Service }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
-
 {{- if .Values.persistence.storageClass }}
   storageClassName: {{ .Values.persistence.storageClass | quote }}
-{{- else }}
-  storageClassName: standard
 {{- end }}
-
 {{- end }}
-

--- a/mosquitto/templates/svc.yaml
+++ b/mosquitto/templates/svc.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }} 
+    heritage: {{ .Release.Service }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/mosquitto/values.yaml
+++ b/mosquitto/values.yaml
@@ -6,9 +6,6 @@ image: smizy/mosquitto:1.4.12-alpine
 
 imagePullPolicy: IfNotPresent
 
-ingress:
-  enabled: false
-
 service:
   enabled: true
   type: "ClusterIP"
@@ -18,11 +15,27 @@ persistence:
   accessMode: ReadWriteOnce
   size: 2Gi
   storageClass: standard
-  
-resources:
-  requests:
-    cpu: 50m
-    memory: 100Mi
+
+deployment:
+  hostNetwork: false
+  probes:
+    livenessProbe:
+      tcpSocket:
+        port: 9090
+      initialDelaySeconds: 5
+      periodSeconds: 1
+    readinessProbe:
+      tcpSocket:
+        port: 9090
+      initialDelaySeconds: 3
+      periodSeconds: 3
+  resources:
+    requests:
+      cpu: 50m
+      memory: 100Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi
 
 config: |-
   log_dest stdout


### PR DESCRIPTION
    - Making chart compatible with Kubernetes' version 1.16 api deprecations
    - Deleting useless trailing spaces in various places
    - Deleting unused values (ingress)
    - `app` label is now the name of the app (not the fullname - app name +
      release name)
    - Added probes to deployment
    - Specify default limits for resources
    - Make sure app is redeployed when config changes