### PR TITLE
respect mosquitto service type

### DIFF
--- a/mosquitto/templates/svc.yaml
+++ b/mosquitto/templates/svc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,10 +9,18 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  type: ClusterIP
-  clusterIP: None
+  type: {{ .Values.service.type }}
+  {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- if eq .Values.service.type "ClusterIP" }}
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  {{- end }}
   ports:
   - name: headless
     port: 1883
   selector:
     app: {{ template "fullname" . }}
+{{- end }}

--- a/mosquitto/values.yaml
+++ b/mosquitto/values.yaml
@@ -9,6 +9,8 @@ imagePullPolicy: IfNotPresent
 service:
   enabled: true
   type: "ClusterIP"
+  externalTrafficPolicy: Local
+  # ClusterIP: None
 
 persistence:
   enabled: true


### PR DESCRIPTION
`values.yaml` allows for configuration of the service type but the value is ignored in the `svc.yaml` of the Mosquitto deployment.

This pull request fixes the issue and also adds options to configure
- the value of `externalTrafficPolicy` for `NodePort` service instances 
- a different value than `None` for `ClusterIP`.