### PR TITLE
allow arbitrary mosquitto images

### DIFF
--- a/mosquitto/templates/deployment.yaml
+++ b/mosquitto/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
       - image: {{ .Values.image }}
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         name: {{ template "fullname" . }}
+        command: ["/usr/sbin/mosquitto", "-c", "/mosquitto/config/mosquitto.conf"]
         ports:
         - containerPort: 1883
           name: "mqtt"


### PR DESCRIPTION
Explicitly stating the command allows using any docker image containing `/usr/sbin/mosquitto` to be used by the chart.